### PR TITLE
Fix stats counter looping

### DIFF
--- a/resources/js/home-page.js
+++ b/resources/js/home-page.js
@@ -190,6 +190,8 @@ function animateCounters() {
 const counters = document.querySelectorAll('.stat-number');
 
 counters.forEach(counter => {
+if (counter.classList.contains('counted')) return;
+counter.classList.add('counted');
 const target = counter.textContent;
 const isNumber = !isNaN(target.replace('+', '').replace('%', ''));
 


### PR DESCRIPTION
## Summary
- ensure stat counters run only once

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_68739bb7b8b48320a40bda21b4b5fa08