### PR TITLE
Remove chatbot and whatsapp livewire components

### DIFF
--- a/resources/views/livewire/home-page.blade.php
+++ b/resources/views/livewire/home-page.blade.php
@@ -11,7 +11,7 @@
     @livewire('faq')
     @livewire('contact')
     @livewire('footer')
-    @livewire('chatbot')
-    @livewire('whatsapp')
-    @livewire('rdv-modal')
+    {{-- @livewire('chatbot') --}}
+    {{-- @livewire('whatsapp') --}}
+    {{-- @livewire('rdv-modal') --}}
 </div>


### PR DESCRIPTION
## Summary
- comment out chatbot, WhatsApp, and RDV modal livewire components on the homepage

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_6876bc2f59988320add236c8219c4b78